### PR TITLE
Add MC tests from LLVM.

### DIFF
--- a/tests/MC/AVR/inst_adc_avr.txt.yaml
+++ b/tests/MC/AVR/inst_adc_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x1c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "adc r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x1c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "adc r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x1f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "adc r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x1f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "adc r31, r16"

--- a/tests/MC/AVR/inst_add_avr.txt.yaml
+++ b/tests/MC/AVR/inst_add_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x0f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x0f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r31, r16"

--- a/tests/MC/AVR/inst_adiw_avr_addsubiw.txt.yaml
+++ b/tests/MC/AVR/inst_adiw_avr_addsubiw.txt.yaml
@@ -1,0 +1,90 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x1c, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r26, 12"
+
+  -
+    input:
+      bytes: [ 0xdf, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r26, 63"
+
+  -
+    input:
+      bytes: [ 0x61, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r28, 17"
+
+  -
+    input:
+      bytes: [ 0x20, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r28, 0"
+
+  -
+    input:
+      bytes: [ 0x33, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r30, 3"
+
+  -
+    input:
+      bytes: [ 0xff, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r30, 63"
+
+  -
+    input:
+      bytes: [ 0xcf, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r24, 63"
+
+  -
+    input:
+      bytes: [ 0x00, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r24, 0"
+
+  -
+    input:
+      bytes: [ 0x30, 0x96 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "adiw r30, 0"

--- a/tests/MC/AVR/inst_and_avr.txt.yaml
+++ b/tests/MC/AVR/inst_and_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x20 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "and r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x20 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "and r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x23 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "and r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x23 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "and r31, r16"

--- a/tests/MC/AVR/inst_andi_avr.txt.yaml
+++ b/tests/MC/AVR/inst_andi_avr.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x7f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r16, 255"
+
+  -
+    input:
+      bytes: [ 0xde, 0x7b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r29, 190"
+
+  -
+    input:
+      bytes: [ 0x6c, 0x7a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r22, 172"
+
+  -
+    input:
+      bytes: [ 0xbc, 0x75 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r27, 92"
+
+  -
+    input:
+      bytes: [ 0x40 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r20, BAR"

--- a/tests/MC/AVR/inst_asr_avr.txt.yaml
+++ b/tests/MC/AVR/inst_asr_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xf5, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "asr r31"
+
+  -
+    input:
+      bytes: [ 0x95, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "asr r25"
+
+  -
+    input:
+      bytes: [ 0x55, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "asr r5"
+
+  -
+    input:
+      bytes: [ 0x05, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "asr r0"

--- a/tests/MC/AVR/inst_bld_avr.txt.yaml
+++ b/tests/MC/AVR/inst_bld_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x35, 0xf8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bld r3, 5"
+
+  -
+    input:
+      bytes: [ 0x11, 0xf8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bld r1, 1"
+
+  -
+    input:
+      bytes: [ 0x00, 0xf8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bld r0, 0"
+
+  -
+    input:
+      bytes: [ 0x72, 0xf8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bld r7, 2"

--- a/tests/MC/AVR/inst_break_avr_break.txt.yaml
+++ b/tests/MC/AVR/inst_break_avr_break.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x98, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "break" ]
+    expected:
+      insns:
+        -
+          asm_text: "break"

--- a/tests/MC/AVR/inst_bst_avr.txt.yaml
+++ b/tests/MC/AVR/inst_bst_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x35, 0xfa ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bst r3, 5"
+
+  -
+    input:
+      bytes: [ 0x11, 0xfa ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bst r1, 1"
+
+  -
+    input:
+      bytes: [ 0x00, 0xfa ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bst r0, 0"
+
+  -
+    input:
+      bytes: [ 0x72, 0xfa ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "bst r7, 2"

--- a/tests/MC/AVR/inst_call_avr_jmpcall.txt.yaml
+++ b/tests/MC/AVR/inst_call_avr_jmpcall.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0e, 0x94, 0x00, 0x08 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "call 4096"
+
+  -
+    input:
+      bytes: [ 0xff, 0x95, 0xc2, 0xff ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "call -124"
+
+  -
+    input:
+      bytes: [ 0xff, 0x95, 0xfa, 0xff ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "call -12"
+
+  -
+    input:
+      bytes: [ 0x0e, 0x94, 0x00, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "call 0"
+
+  -
+    input:
+      bytes: [ 0x0e ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "call r25"

--- a/tests/MC/AVR/inst_cbi_avr.txt.yaml
+++ b/tests/MC/AVR/inst_cbi_avr.txt.yaml
@@ -1,0 +1,70 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x1d, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 3, 5"
+
+  -
+    input:
+      bytes: [ 0x09, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 1, 1"
+
+  -
+    input:
+      bytes: [ 0x3a, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 7, 2"
+
+  -
+    input:
+      bytes: [ 0x00, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 0, 0"
+
+  -
+    input:
+      bytes: [ 0xf8, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 31, 0"
+
+  -
+    input:
+      bytes: [ 0x07, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 0, 7"
+
+  -
+    input:
+      bytes: [ 0xff, 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cbi 31, 7"

--- a/tests/MC/AVR/inst_cbr_avr.txt.yaml
+++ b/tests/MC/AVR/inst_cbr_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x1f, 0x72 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r17, -209"
+
+  -
+    input:
+      bytes: [ 0x81, 0x74 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r24, -191"
+
+  -
+    input:
+      bytes: [ 0x42, 0x75 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r20, -174"
+
+  -
+    input:
+      bytes: [ 0xff, 0x7f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "andi r31, -1"

--- a/tests/MC/AVR/inst_clr_avr.txt.yaml
+++ b/tests/MC/AVR/inst_clr_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x22, 0x24 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clr r2"
+
+  -
+    input:
+      bytes: [ 0xcc, 0x24 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clr r12"
+
+  -
+    input:
+      bytes: [ 0x55, 0x24 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clr r5"
+
+  -
+    input:
+      bytes: [ 0x00, 0x24 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clr r0"

--- a/tests/MC/AVR/inst_com_avr.txt.yaml
+++ b/tests/MC/AVR/inst_com_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xe0, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "com r30"
+
+  -
+    input:
+      bytes: [ 0x10, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "com r17"
+
+  -
+    input:
+      bytes: [ 0x40, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "com r4"
+
+  -
+    input:
+      bytes: [ 0x00, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "com r0"

--- a/tests/MC/AVR/inst_cp_avr.txt.yaml
+++ b/tests/MC/AVR/inst_cp_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xc2, 0x14 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r12, r2"
+
+  -
+    input:
+      bytes: [ 0x30, 0x15 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r19, r0"
+
+  -
+    input:
+      bytes: [ 0xff, 0x16 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r15, r31"
+
+  -
+    input:
+      bytes: [ 0x00, 0x14 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r0, r0"

--- a/tests/MC/AVR/inst_cpc_avr.txt.yaml
+++ b/tests/MC/AVR/inst_cpc_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xdc, 0x14 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r13, r12"
+
+  -
+    input:
+      bytes: [ 0x40, 0x15 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r20, r0"
+
+  -
+    input:
+      bytes: [ 0xaf, 0x16 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r10, r31"
+
+  -
+    input:
+      bytes: [ 0x00, 0x14 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cp r0, r0"

--- a/tests/MC/AVR/inst_cpi_avr.txt.yaml
+++ b/tests/MC/AVR/inst_cpi_avr.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x01, 0x3f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpi r16, 241"
+
+  -
+    input:
+      bytes: [ 0xde, 0x3b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpi r29, 190"
+
+  -
+    input:
+      bytes: [ 0x6c, 0x3a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpi r22, 172"
+
+  -
+    input:
+      bytes: [ 0xbc, 0x35 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpi r27, 92"
+
+  -
+    input:
+      bytes: [ 0x50 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpi r21, ear"

--- a/tests/MC/AVR/inst_cpse_avr.txt.yaml
+++ b/tests/MC/AVR/inst_cpse_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x2d, 0x10 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpse r2, r13"
+
+  -
+    input:
+      bytes: [ 0x90, 0x10 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpse r9, r0"
+
+  -
+    input:
+      bytes: [ 0x5f, 0x12 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpse r5, r31"
+
+  -
+    input:
+      bytes: [ 0x33, 0x10 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cpse r3, r3"

--- a/tests/MC/AVR/inst_dec_avr.txt.yaml
+++ b/tests/MC/AVR/inst_dec_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xaa, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "dec r26"
+
+  -
+    input:
+      bytes: [ 0x3a, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "dec r3"
+
+  -
+    input:
+      bytes: [ 0x8a, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "dec r24"
+
+  -
+    input:
+      bytes: [ 0x4a, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "dec r20"

--- a/tests/MC/AVR/inst_des_avr_des.txt.yaml
+++ b/tests/MC/AVR/inst_des_avr_des.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0b, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "des" ]
+    expected:
+      insns:
+        -
+          asm_text: "des 0"
+
+  -
+    input:
+      bytes: [ 0x6b, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "des" ]
+    expected:
+      insns:
+        -
+          asm_text: "des 6"
+
+  -
+    input:
+      bytes: [ 0x1b, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "des" ]
+    expected:
+      insns:
+        -
+          asm_text: "des 1"
+
+  -
+    input:
+      bytes: [ 0x8b, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "des" ]
+    expected:
+      insns:
+        -
+          asm_text: "des 8"

--- a/tests/MC/AVR/inst_eicall_avr_eijmpcall.txt.yaml
+++ b/tests/MC/AVR/inst_eicall_avr_eijmpcall.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x19, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "eijmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "eicall"

--- a/tests/MC/AVR/inst_eijmp_avr_eijmpcall.txt.yaml
+++ b/tests/MC/AVR/inst_eijmp_avr_eijmpcall.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x19, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "eijmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "eijmp"

--- a/tests/MC/AVR/inst_elpm_avr_elpm_elpmx.txt.yaml
+++ b/tests/MC/AVR/inst_elpm_avr_elpm_elpmx.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xd8, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "elpm", "elpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "elpm"
+
+  -
+    input:
+      bytes: [ 0x36, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "elpm", "elpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "elpm r3, Z"
+
+  -
+    input:
+      bytes: [ 0x76, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "elpm", "elpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "elpm r23, Z"
+
+  -
+    input:
+      bytes: [ 0x87, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "elpm", "elpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "elpm r8, Z+"
+
+  -
+    input:
+      bytes: [ 0x07, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "elpm", "elpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "elpm r0, Z+"

--- a/tests/MC/AVR/inst_eor_avr.txt.yaml
+++ b/tests/MC/AVR/inst_eor_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x24 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "eor r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x24 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "eor r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x27 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "eor r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x27 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "eor r31, r16"

--- a/tests/MC/AVR/inst_family_set_clr_flag_avr.txt.yaml
+++ b/tests/MC/AVR/inst_family_set_clr_flag_avr.txt.yaml
@@ -1,0 +1,160 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x08, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sec"
+
+  -
+    input:
+      bytes: [ 0x18, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sez"
+
+  -
+    input:
+      bytes: [ 0x28, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sen"
+
+  -
+    input:
+      bytes: [ 0x38, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sev"
+
+  -
+    input:
+      bytes: [ 0x48, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ses"
+
+  -
+    input:
+      bytes: [ 0x58, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "seh"
+
+  -
+    input:
+      bytes: [ 0x68, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "set"
+
+  -
+    input:
+      bytes: [ 0x78, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sei"
+
+  -
+    input:
+      bytes: [ 0x88, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clc"
+
+  -
+    input:
+      bytes: [ 0x98, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clz"
+
+  -
+    input:
+      bytes: [ 0xa8, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cln"
+
+  -
+    input:
+      bytes: [ 0xb8, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clv"
+
+  -
+    input:
+      bytes: [ 0xc8, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cls"
+
+  -
+    input:
+      bytes: [ 0xd8, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clh"
+
+  -
+    input:
+      bytes: [ 0xe8, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "clt"
+
+  -
+    input:
+      bytes: [ 0xf8, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "cli"

--- a/tests/MC/AVR/inst_fmul_avr_mul.txt.yaml
+++ b/tests/MC/AVR/inst_fmul_avr_mul.txt.yaml
@@ -1,0 +1,60 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x68, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmul r22, r16"
+
+  -
+    input:
+      bytes: [ 0x39, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmul r19, r17"
+
+  -
+    input:
+      bytes: [ 0x5f, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmul r21, r23"
+
+  -
+    input:
+      bytes: [ 0x7f, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmul r23, r23"
+
+  -
+    input:
+      bytes: [ 0x08, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmul r16, r16"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmul r16, r23"

--- a/tests/MC/AVR/inst_fmuls_avr_mul.txt.yaml
+++ b/tests/MC/AVR/inst_fmuls_avr_mul.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xe0, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmuls r22, r16"
+
+  -
+    input:
+      bytes: [ 0xb1, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmuls r19, r17"
+
+  -
+    input:
+      bytes: [ 0xd7, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmuls r21, r23"
+
+  -
+    input:
+      bytes: [ 0xf7, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmuls r23, r23"

--- a/tests/MC/AVR/inst_fmulsu_avr_mul.txt.yaml
+++ b/tests/MC/AVR/inst_fmulsu_avr_mul.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xe8, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmulsu r22, r16"
+
+  -
+    input:
+      bytes: [ 0xb9, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmulsu r19, r17"
+
+  -
+    input:
+      bytes: [ 0xdf, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmulsu r21, r23"
+
+  -
+    input:
+      bytes: [ 0xff, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "fmulsu r23, r23"

--- a/tests/MC/AVR/inst_icall_avr_ijmpcall.txt.yaml
+++ b/tests/MC/AVR/inst_icall_avr_ijmpcall.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x09, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "ijmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "icall"

--- a/tests/MC/AVR/inst_ijmp_avr_ijmpcall.txt.yaml
+++ b/tests/MC/AVR/inst_ijmp_avr_ijmpcall.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x09, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "ijmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "ijmp"

--- a/tests/MC/AVR/inst_in_avr.txt.yaml
+++ b/tests/MC/AVR/inst_in_avr.txt.yaml
@@ -1,0 +1,80 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x24, 0xb0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r2, 4"
+
+  -
+    input:
+      bytes: [ 0x96, 0xb0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r9, 6"
+
+  -
+    input:
+      bytes: [ 0x50, 0xb4 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r5, 32"
+
+  -
+    input:
+      bytes: [ 0x00, 0xb0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r0, 0"
+
+  -
+    input:
+      bytes: [ 0xf0, 0xb1 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r31, 0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0xb6 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r0, 63"
+
+  -
+    input:
+      bytes: [ 0xff, 0xb7 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r31, 63"
+
+  -
+    input:
+      bytes: [ 0x40 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "in r20, foo+1"

--- a/tests/MC/AVR/inst_inc_avr.txt.yaml
+++ b/tests/MC/AVR/inst_inc_avr.txt.yaml
@@ -1,0 +1,60 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xc3, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r12"
+
+  -
+    input:
+      bytes: [ 0xd3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r29"
+
+  -
+    input:
+      bytes: [ 0x63, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r6"
+
+  -
+    input:
+      bytes: [ 0x43, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r20"
+
+  -
+    input:
+      bytes: [ 0x03, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r0"
+
+  -
+    input:
+      bytes: [ 0xf3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r31"

--- a/tests/MC/AVR/inst_jmp_avr_jmpcall.txt.yaml
+++ b/tests/MC/AVR/inst_jmp_avr_jmpcall.txt.yaml
@@ -1,0 +1,80 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0c, 0x94, 0x64, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp 200"
+
+  -
+    input:
+      bytes: [ 0xfd, 0x95, 0xfa, 0xff ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp -12"
+
+  -
+    input:
+      bytes: [ 0x0c, 0x94, 0x28, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp 80"
+
+  -
+    input:
+      bytes: [ 0x0c, 0x94, 0x00, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp 0"
+
+  -
+    input:
+      bytes: [ 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp foo+1"
+
+  -
+    input:
+      bytes: [ 0x0d, 0x94, 0xff, 0xff ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp 262142"
+
+  -
+    input:
+      bytes: [ 0xfc, 0x95, 0x00, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp 8126464"
+
+  -
+    input:
+      bytes: [ 0xfd, 0x95, 0xff, 0xff ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "jmpcall" ]
+    expected:
+      insns:
+        -
+          asm_text: "jmp 8388606"

--- a/tests/MC/AVR/inst_lac_avr_rmw.txt.yaml
+++ b/tests/MC/AVR/inst_lac_avr_rmw.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xd6, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lac Z, r13"
+
+  -
+    input:
+      bytes: [ 0x06, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lac Z, r0"
+
+  -
+    input:
+      bytes: [ 0xf6, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lac Z, r31"
+
+  -
+    input:
+      bytes: [ 0x36, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lac Z, r3"

--- a/tests/MC/AVR/inst_las_avr_rmw.txt.yaml
+++ b/tests/MC/AVR/inst_las_avr_rmw.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xd5, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "las Z, r13"
+
+  -
+    input:
+      bytes: [ 0x05, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "las Z, r0"
+
+  -
+    input:
+      bytes: [ 0xf5, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "las Z, r31"
+
+  -
+    input:
+      bytes: [ 0x35, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "las Z, r3"

--- a/tests/MC/AVR/inst_lat_avr_rmw.txt.yaml
+++ b/tests/MC/AVR/inst_lat_avr_rmw.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xd7, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lat Z, r13"
+
+  -
+    input:
+      bytes: [ 0x07, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lat Z, r0"
+
+  -
+    input:
+      bytes: [ 0xf7, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lat Z, r31"
+
+  -
+    input:
+      bytes: [ 0x37, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "lat Z, r3"

--- a/tests/MC/AVR/inst_ld_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_ld_avr_sram.txt.yaml
@@ -1,0 +1,180 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xac, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r10, X"
+
+  -
+    input:
+      bytes: [ 0x1c, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r17, X"
+
+  -
+    input:
+      bytes: [ 0xe8, 0x81 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r30, Y"
+
+  -
+    input:
+      bytes: [ 0x38, 0x81 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r19, Y"
+
+  -
+    input:
+      bytes: [ 0xa0, 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r10, Z"
+
+  -
+    input:
+      bytes: [ 0x20, 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r2, Z"
+
+  -
+    input:
+      bytes: [ 0xad, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r10, X+"
+
+  -
+    input:
+      bytes: [ 0x1d, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r17, X+"
+
+  -
+    input:
+      bytes: [ 0xe9, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r30, Y+"
+
+  -
+    input:
+      bytes: [ 0x39, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r19, Y+"
+
+  -
+    input:
+      bytes: [ 0xa1, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r10, Z+"
+
+  -
+    input:
+      bytes: [ 0x21, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r2, Z+"
+
+  -
+    input:
+      bytes: [ 0xae, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r10, -X"
+
+  -
+    input:
+      bytes: [ 0x1e, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r17, -X"
+
+  -
+    input:
+      bytes: [ 0xea, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r30, -Y"
+
+  -
+    input:
+      bytes: [ 0x3a, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r19, -Y"
+
+  -
+    input:
+      bytes: [ 0xa2, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r10, -Z"
+
+  -
+    input:
+      bytes: [ 0x22, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ld r2, -Z"

--- a/tests/MC/AVR/inst_ldd_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_ldd_avr_sram.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x2a, 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldd r2, Y+2"
+
+  -
+    input:
+      bytes: [ 0x08, 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldd r0, Y+0"
+
+  -
+    input:
+      bytes: [ 0x94, 0x84 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldd r9, Z+12"
+
+  -
+    input:
+      bytes: [ 0x76, 0x8c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldd r7, Z+30"
+
+  -
+    input:
+      bytes: [ 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldd r9, Z+foo"

--- a/tests/MC/AVR/inst_ldi_avr.txt.yaml
+++ b/tests/MC/AVR/inst_ldi_avr.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x01, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r16, 241"
+
+  -
+    input:
+      bytes: [ 0xde, 0xeb ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r29, 190"
+
+  -
+    input:
+      bytes: [ 0x6c, 0xea ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r22, 172"
+
+  -
+    input:
+      bytes: [ 0xbc, 0xe5 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r27, 92"
+
+  -
+    input:
+      bytes: [ 0x50 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r21, SYMBOL+3"

--- a/tests/MC/AVR/inst_lds_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_lds_avr_sram.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x00, 0x91, 0xf1, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r16, 241"
+
+  -
+    input:
+      bytes: [ 0xd0, 0x91, 0xbe, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r29, 190"
+
+  -
+    input:
+      bytes: [ 0x60, 0x91, 0xac, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r22, 172"
+
+  -
+    input:
+      bytes: [ 0xb0, 0x91, 0x5c, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r27, 92"

--- a/tests/MC/AVR/inst_lds_tiny_avr_sram_tinyencoding.txt.yaml
+++ b/tests/MC/AVR/inst_lds_tiny_avr_sram_tinyencoding.txt.yaml
@@ -1,0 +1,70 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x01, 0xa7 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r16, 113"
+
+  -
+    input:
+      bytes: [ 0xde, 0xa3 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r29, 62"
+
+  -
+    input:
+      bytes: [ 0x6c, 0xa2 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r22, 44"
+
+  -
+    input:
+      bytes: [ 0xbc, 0xa5 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r27, 92"
+
+  -
+    input:
+      bytes: [ 0x40 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r20, SYMBOL+12"
+
+  -
+    input:
+      bytes: [ 0x40 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r20, r21"
+
+  -
+    input:
+      bytes: [ 0x40 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "lds r20, z+6"

--- a/tests/MC/AVR/inst_lpm_avr_lpm_lpmx.txt.yaml
+++ b/tests/MC/AVR/inst_lpm_avr_lpm_lpmx.txt.yaml
@@ -1,0 +1,60 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xc8, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "lpm", "lpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "lpm"
+
+  -
+    input:
+      bytes: [ 0x34, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "lpm", "lpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "lpm r3, Z"
+
+  -
+    input:
+      bytes: [ 0x74, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "lpm", "lpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "lpm r23, Z"
+
+  -
+    input:
+      bytes: [ 0x85, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "lpm", "lpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "lpm r8, Z+"
+
+  -
+    input:
+      bytes: [ 0x05, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "lpm", "lpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "lpm r0, Z+"
+
+  -
+    input:
+      bytes: [ 0xf5, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "lpm", "lpmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "lpm r31, Z+"

--- a/tests/MC/AVR/inst_lsl_avr.txt.yaml
+++ b/tests/MC/AVR/inst_lsl_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xff, 0x0f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsl r31"
+
+  -
+    input:
+      bytes: [ 0x99, 0x0f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsl r25"
+
+  -
+    input:
+      bytes: [ 0x55, 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsl r5"
+
+  -
+    input:
+      bytes: [ 0x00, 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsl r0"

--- a/tests/MC/AVR/inst_lsr_avr.txt.yaml
+++ b/tests/MC/AVR/inst_lsr_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xf6, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsr r31"
+
+  -
+    input:
+      bytes: [ 0x96, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsr r25"
+
+  -
+    input:
+      bytes: [ 0x56, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsr r5"
+
+  -
+    input:
+      bytes: [ 0x06, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "lsr r0"

--- a/tests/MC/AVR/inst_mov_avr.txt.yaml
+++ b/tests/MC/AVR/inst_mov_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x2d, 0x2c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "mov r2, r13"
+
+  -
+    input:
+      bytes: [ 0x90, 0x2c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "mov r9, r0"
+
+  -
+    input:
+      bytes: [ 0x5f, 0x2e ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "mov r5, r31"
+
+  -
+    input:
+      bytes: [ 0x33, 0x2c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "mov r3, r3"

--- a/tests/MC/AVR/inst_movw_avr_movw.txt.yaml
+++ b/tests/MC/AVR/inst_movw_avr_movw.txt.yaml
@@ -1,0 +1,80 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x54, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r10, r8"
+
+  -
+    input:
+      bytes: [ 0x68, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r12, r16"
+
+  -
+    input:
+      bytes: [ 0xab, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r20, r22"
+
+  -
+    input:
+      bytes: [ 0x46, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r8, r12"
+
+  -
+    input:
+      bytes: [ 0x00, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r0, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r0, r30"
+
+  -
+    input:
+      bytes: [ 0xff, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r30, r30"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x01 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "movw" ]
+    expected:
+      insns:
+        -
+          asm_text: "movw r30, r0"

--- a/tests/MC/AVR/inst_mul_avr_mul.txt.yaml
+++ b/tests/MC/AVR/inst_mul_avr_mul.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x9c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mul r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x9c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mul r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x9f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mul r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x9f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mul r31, r16"

--- a/tests/MC/AVR/inst_muls_avr_mul.txt.yaml
+++ b/tests/MC/AVR/inst_muls_avr_mul.txt.yaml
@@ -1,0 +1,60 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x60, 0x02 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "muls r22, r16"
+
+  -
+    input:
+      bytes: [ 0x31, 0x02 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "muls r19, r17"
+
+  -
+    input:
+      bytes: [ 0xcf, 0x02 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "muls r28, r31"
+
+  -
+    input:
+      bytes: [ 0xff, 0x02 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "muls r31, r31"
+
+  -
+    input:
+      bytes: [ 0x00, 0x02 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "muls r16, r16"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x02 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "muls r16, r31"

--- a/tests/MC/AVR/inst_mulsu_avr_mul.txt.yaml
+++ b/tests/MC/AVR/inst_mulsu_avr_mul.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x60, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mulsu r22, r16"
+
+  -
+    input:
+      bytes: [ 0x31, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mulsu r19, r17"
+
+  -
+    input:
+      bytes: [ 0x57, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mulsu r21, r23"
+
+  -
+    input:
+      bytes: [ 0x77, 0x03 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "mul" ]
+    expected:
+      insns:
+        -
+          asm_text: "mulsu r23, r23"

--- a/tests/MC/AVR/inst_neg_avr.txt.yaml
+++ b/tests/MC/AVR/inst_neg_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xf1, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "neg r15"
+
+  -
+    input:
+      bytes: [ 0x11, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "neg r1"
+
+  -
+    input:
+      bytes: [ 0x61, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "neg r22"
+
+  -
+    input:
+      bytes: [ 0xf1, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "neg r31"

--- a/tests/MC/AVR/inst_nop_avr.txt.yaml
+++ b/tests/MC/AVR/inst_nop_avr.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x00, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "nop"

--- a/tests/MC/AVR/inst_or_avr.txt.yaml
+++ b/tests/MC/AVR/inst_or_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x28 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "or r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x28 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "or r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x2b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "or r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x2b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "or r31, r16"

--- a/tests/MC/AVR/inst_ori_avr.txt.yaml
+++ b/tests/MC/AVR/inst_ori_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x10, 0x6d ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r17, 208"
+
+  -
+    input:
+      bytes: [ 0x8e, 0x6b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r24, 190"
+
+  -
+    input:
+      bytes: [ 0x4d, 0x6a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r20, 173"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x60 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r31, 0"

--- a/tests/MC/AVR/inst_out_avr.txt.yaml
+++ b/tests/MC/AVR/inst_out_avr.txt.yaml
@@ -1,0 +1,80 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x24, 0xb8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 4, r2"
+
+  -
+    input:
+      bytes: [ 0x96, 0xb8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 6, r9"
+
+  -
+    input:
+      bytes: [ 0x50, 0xbc ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 32, r5"
+
+  -
+    input:
+      bytes: [ 0x00, 0xb8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 0, r0"
+
+  -
+    input:
+      bytes: [ 0xf0, 0xb9 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 0, r31"
+
+  -
+    input:
+      bytes: [ 0x0f, 0xbe ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 63, r0"
+
+  -
+    input:
+      bytes: [ 0xff, 0xbf ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out 63, r31"
+
+  -
+    input:
+      bytes: [ 0xd0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "out bar-8, r29"

--- a/tests/MC/AVR/inst_pop_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_pop_avr_sram.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xff, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "pop r31"
+
+  -
+    input:
+      bytes: [ 0x9f, 0x91 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "pop r25"
+
+  -
+    input:
+      bytes: [ 0x5f, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "pop r5"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "pop r0"

--- a/tests/MC/AVR/inst_push_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_push_avr_sram.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xff, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "push r31"
+
+  -
+    input:
+      bytes: [ 0x9f, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "push r25"
+
+  -
+    input:
+      bytes: [ 0x5f, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "push r5"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "push r0"

--- a/tests/MC/AVR/inst_ret_avr.txt.yaml
+++ b/tests/MC/AVR/inst_ret_avr.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x08, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ret"

--- a/tests/MC/AVR/inst_reti_avr.txt.yaml
+++ b/tests/MC/AVR/inst_reti_avr.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x18, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "reti"

--- a/tests/MC/AVR/inst_rol_avr.txt.yaml
+++ b/tests/MC/AVR/inst_rol_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xff, 0x1f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "rol r31"
+
+  -
+    input:
+      bytes: [ 0x99, 0x1f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "rol r25"
+
+  -
+    input:
+      bytes: [ 0x55, 0x1c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "rol r5"
+
+  -
+    input:
+      bytes: [ 0x00, 0x1c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "rol r0"

--- a/tests/MC/AVR/inst_ror_avr.txt.yaml
+++ b/tests/MC/AVR/inst_ror_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xf7, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ror r31"
+
+  -
+    input:
+      bytes: [ 0x97, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ror r25"
+
+  -
+    input:
+      bytes: [ 0x57, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ror r5"
+
+  -
+    input:
+      bytes: [ 0x07, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ror r0"

--- a/tests/MC/AVR/inst_sbc_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbc_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x08 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbc r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x08 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbc r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x0b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbc r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x0b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbc r31, r16"

--- a/tests/MC/AVR/inst_sbci_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbci_avr.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x15, 0x41 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbci r17, 21"
+
+  -
+    input:
+      bytes: [ 0x74, 0x4c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbci r23, 196"
+
+  -
+    input:
+      bytes: [ 0xe4, 0x4f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbci r30, 244"
+
+  -
+    input:
+      bytes: [ 0x30, 0x41 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbci r19, 16"
+
+  -
+    input:
+      bytes: [ 0x60 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbci r22, FOO"

--- a/tests/MC/AVR/inst_sbi_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbi_avr.txt.yaml
@@ -1,0 +1,70 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x1d, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 3, 5"
+
+  -
+    input:
+      bytes: [ 0x09, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 1, 1"
+
+  -
+    input:
+      bytes: [ 0x3a, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 7, 2"
+
+  -
+    input:
+      bytes: [ 0x00, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 0, 0"
+
+  -
+    input:
+      bytes: [ 0x07, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 0, 7"
+
+  -
+    input:
+      bytes: [ 0xf8, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 31, 0"
+
+  -
+    input:
+      bytes: [ 0xff, 0x9a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbi 31, 7"

--- a/tests/MC/AVR/inst_sbic_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbic_avr.txt.yaml
@@ -1,0 +1,70 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x23, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 4, 3"
+
+  -
+    input:
+      bytes: [ 0x32, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 6, 2"
+
+  -
+    input:
+      bytes: [ 0x85, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 16, 5"
+
+  -
+    input:
+      bytes: [ 0x00, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 0, 0"
+
+  -
+    input:
+      bytes: [ 0xf8, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 31, 0"
+
+  -
+    input:
+      bytes: [ 0x07, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 0, 7"
+
+  -
+    input:
+      bytes: [ 0xff, 0x99 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbic 31, 7"

--- a/tests/MC/AVR/inst_sbis_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbis_avr.txt.yaml
@@ -1,0 +1,70 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x23, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 4, 3"
+
+  -
+    input:
+      bytes: [ 0x32, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 6, 2"
+
+  -
+    input:
+      bytes: [ 0x85, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 16, 5"
+
+  -
+    input:
+      bytes: [ 0x00, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 0, 0"
+
+  -
+    input:
+      bytes: [ 0xf8, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 31, 0"
+
+  -
+    input:
+      bytes: [ 0x07, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 0, 7"
+
+  -
+    input:
+      bytes: [ 0xff, 0x9b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbis 31, 7"

--- a/tests/MC/AVR/inst_sbiw_avr_addsubiw.txt.yaml
+++ b/tests/MC/AVR/inst_sbiw_avr_addsubiw.txt.yaml
@@ -1,0 +1,80 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xd6, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r26, 54"
+
+  -
+    input:
+      bytes: [ 0xdf, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r26, 63"
+
+  -
+    input:
+      bytes: [ 0xe4, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r28, 52"
+
+  -
+    input:
+      bytes: [ 0x20, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r28, 0"
+
+  -
+    input:
+      bytes: [ 0xff, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r30, 63"
+
+  -
+    input:
+      bytes: [ 0xbf, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r30, 47"
+
+  -
+    input:
+      bytes: [ 0x01, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r24, 1"
+
+  -
+    input:
+      bytes: [ 0x02, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r24, 2"

--- a/tests/MC/AVR/inst_sbr_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbr_avr.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x10, 0x6d ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r17, 208"
+
+  -
+    input:
+      bytes: [ 0x8e, 0x6b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r24, 190"
+
+  -
+    input:
+      bytes: [ 0x4d, 0x6a ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r20, 173"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x60 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r31, 0"
+
+  -
+    input:
+      bytes: [ 0x30 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ori r19, _start"

--- a/tests/MC/AVR/inst_sbrc_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbrc_avr.txt.yaml
@@ -1,0 +1,20 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x23, 0xfc ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbrc r2, 3"
+
+  -
+    input:
+      bytes: [ 0x07, 0xfc ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbrc r0, 7"

--- a/tests/MC/AVR/inst_sbrs_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sbrs_avr.txt.yaml
@@ -1,0 +1,20 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x23, 0xfe ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbrs r2, 3"
+
+  -
+    input:
+      bytes: [ 0x07, 0xfe ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbrs r0, 7"

--- a/tests/MC/AVR/inst_ser_avr.txt.yaml
+++ b/tests/MC/AVR/inst_ser_avr.txt.yaml
@@ -1,0 +1,30 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r16, 255"
+
+  -
+    input:
+      bytes: [ 0xff, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r31, 255"
+
+  -
+    input:
+      bytes: [ 0xbf, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r27, 255"

--- a/tests/MC/AVR/inst_sleep_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sleep_avr.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x88, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sleep"

--- a/tests/MC/AVR/inst_spm_avr_spm_spmx.txt.yaml
+++ b/tests/MC/AVR/inst_spm_avr_spm_spmx.txt.yaml
@@ -1,0 +1,20 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xe8, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "spm", "spmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "spm"
+
+  -
+    input:
+      bytes: [ 0xf8, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "spm", "spmx" ]
+    expected:
+      insns:
+        -
+          asm_text: "spm Z+"

--- a/tests/MC/AVR/inst_st_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_st_avr_sram.txt.yaml
@@ -1,0 +1,180 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xac, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st X, r10"
+
+  -
+    input:
+      bytes: [ 0x1c, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st X, r17"
+
+  -
+    input:
+      bytes: [ 0xe8, 0x83 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Y, r30"
+
+  -
+    input:
+      bytes: [ 0x38, 0x83 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Y, r19"
+
+  -
+    input:
+      bytes: [ 0xa0, 0x82 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Z, r10"
+
+  -
+    input:
+      bytes: [ 0x20, 0x82 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Z, r2"
+
+  -
+    input:
+      bytes: [ 0xad, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st X+, r10"
+
+  -
+    input:
+      bytes: [ 0x1d, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st X+, r17"
+
+  -
+    input:
+      bytes: [ 0xe9, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Y+, r30"
+
+  -
+    input:
+      bytes: [ 0x39, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Y+, r19"
+
+  -
+    input:
+      bytes: [ 0xa1, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Z+, r10"
+
+  -
+    input:
+      bytes: [ 0x21, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st Z+, r2"
+
+  -
+    input:
+      bytes: [ 0xae, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st -X, r10"
+
+  -
+    input:
+      bytes: [ 0x1e, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st -X, r17"
+
+  -
+    input:
+      bytes: [ 0xea, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st -Y, r30"
+
+  -
+    input:
+      bytes: [ 0x3a, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st -Y, r19"
+
+  -
+    input:
+      bytes: [ 0xa2, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st -Z, r10"
+
+  -
+    input:
+      bytes: [ 0x22, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "st -Z, r2"

--- a/tests/MC/AVR/inst_std_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_std_avr_sram.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x2a, 0x82 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "std Y+2, r2"
+
+  -
+    input:
+      bytes: [ 0x08, 0x82 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "std Y+0, r0"
+
+  -
+    input:
+      bytes: [ 0x94, 0x86 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "std Z+12, r9"
+
+  -
+    input:
+      bytes: [ 0x76, 0x8e ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "std Z+30, r7"
+
+  -
+    input:
+      bytes: [ 0x98 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "std Y+foo, r9"

--- a/tests/MC/AVR/inst_sts_avr_sram.txt.yaml
+++ b/tests/MC/AVR/inst_sts_avr_sram.txt.yaml
@@ -1,0 +1,20 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x50, 0x92, 0x03, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts 3, r5"
+
+  -
+    input:
+      bytes: [ 0x70, 0x92, 0xff, 0x00 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts 255, r7"

--- a/tests/MC/AVR/inst_sts_tiny_avr_sram_tinyencoding.txt.yaml
+++ b/tests/MC/AVR/inst_sts_tiny_avr_sram_tinyencoding.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x03, 0xa8 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts 3, r16"
+
+  -
+    input:
+      bytes: [ 0x1f, 0xaf ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts 127, r17"
+
+  -
+    input:
+      bytes: [ 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts SYMBOL+1, r25"
+
+  -
+    input:
+      bytes: [ 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts x, r25"
+
+  -
+    input:
+      bytes: [ 0x90 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "sram", "tinyencoding" ]
+    expected:
+      insns:
+        -
+          asm_text: "sts r25+1, r25"

--- a/tests/MC/AVR/inst_sub_avr.txt.yaml
+++ b/tests/MC/AVR/inst_sub_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x18 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sub r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x18 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sub r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x1b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sub r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x1b ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "sub r31, r16"

--- a/tests/MC/AVR/inst_subi_avr.txt.yaml
+++ b/tests/MC/AVR/inst_subi_avr.txt.yaml
@@ -1,0 +1,50 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x62, 0x55 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "subi r22, 82"
+
+  -
+    input:
+      bytes: [ 0xb7, 0x52 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "subi r27, 39"
+
+  -
+    input:
+      bytes: [ 0xf4, 0x5f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "subi r31, 244"
+
+  -
+    input:
+      bytes: [ 0x00, 0x59 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "subi r16, 144"
+
+  -
+    input:
+      bytes: [ 0x40 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "subi r20, EXTERN_SYMBOL+0"

--- a/tests/MC/AVR/inst_swap_avr.txt.yaml
+++ b/tests/MC/AVR/inst_swap_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xf2, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "swap r31"
+
+  -
+    input:
+      bytes: [ 0x92, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "swap r25"
+
+  -
+    input:
+      bytes: [ 0x52, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "swap r5"
+
+  -
+    input:
+      bytes: [ 0x02, 0x94 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "swap r0"

--- a/tests/MC/AVR/inst_tst_avr.txt.yaml
+++ b/tests/MC/AVR/inst_tst_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x33, 0x20 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "tst r3"
+
+  -
+    input:
+      bytes: [ 0xee, 0x20 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "tst r14"
+
+  -
+    input:
+      bytes: [ 0x88, 0x23 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "tst r24"
+
+  -
+    input:
+      bytes: [ 0xcc, 0x20 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "tst r12"

--- a/tests/MC/AVR/inst_wdr_avr.txt.yaml
+++ b/tests/MC/AVR/inst_wdr_avr.txt.yaml
@@ -1,0 +1,10 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xa8, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "wdr"

--- a/tests/MC/AVR/inst_xch_avr_rmw.txt.yaml
+++ b/tests/MC/AVR/inst_xch_avr_rmw.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xd4, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "xch Z, r13"
+
+  -
+    input:
+      bytes: [ 0x04, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "xch Z, r0"
+
+  -
+    input:
+      bytes: [ 0xf4, 0x93 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "xch Z, r31"
+
+  -
+    input:
+      bytes: [ 0x34, 0x92 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "rmw" ]
+    expected:
+      insns:
+        -
+          asm_text: "xch Z, r3"

--- a/tests/MC/AVR/modifiers_avr.txt.yaml
+++ b/tests/MC/AVR/modifiers_avr.txt.yaml
@@ -1,0 +1,440 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x82, 0xe4 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(66)"
+
+  -
+    input:
+      bytes: [ 0x82, 0xe4 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(9026)"
+
+  -
+    input:
+      bytes: [ 0x83, 0xe2 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(35)"
+
+  -
+    input:
+      bytes: [ 0x83, 0xe2 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(9026)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(bar)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(bar)"
+
+  -
+    input:
+      bytes: [ 0x85, 0xe1 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x80, 0xec ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(-(123456))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, lo8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x88, 0xe0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x8d, 0xe1 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(-(123456))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hi8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x80, 0xe0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hh8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hh8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hh8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x8e, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hh8(-(123456))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hh8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x80, 0xe0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hhi8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hhi8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hhi8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x8f, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hhi8(-(123456))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, hhi8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x8a, 0xe0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_lo8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_lo8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_lo8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x84, 0xe0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hi8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hi8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hi8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x80, 0xe0 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hh8(2069)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hh8(foo)"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hh8(bar+5)"
+
+  -
+    input:
+      bytes: [ 0x85, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_lo8(-(2069))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_lo8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_lo8(-(bar+5))"
+
+  -
+    input:
+      bytes: [ 0x8b, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hi8(-(2069))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hi8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hi8(-(bar+5))"
+
+  -
+    input:
+      bytes: [ 0x8f, 0xef ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hh8(-(2069))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hh8(-(foo))"
+
+  -
+    input:
+      bytes: [ 0x80 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "ldi r24, pm_hh8(-(bar+5))"

--- a/tests/MC/AVR/registers_avr.txt.yaml
+++ b/tests/MC/AVR/registers_avr.txt.yaml
@@ -1,0 +1,60 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0xa3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r26"
+
+  -
+    input:
+      bytes: [ 0xb3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r27"
+
+  -
+    input:
+      bytes: [ 0xc3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r28"
+
+  -
+    input:
+      bytes: [ 0xd3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r29"
+
+  -
+    input:
+      bytes: [ 0xe3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r30"
+
+  -
+    input:
+      bytes: [ 0xf3, 0x95 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "inc r31"

--- a/tests/MC/AVR/syntax_reg_int_literal_avr.txt.yaml
+++ b/tests/MC/AVR/syntax_reg_int_literal_avr.txt.yaml
@@ -1,0 +1,40 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x0f, 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r0, r15"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x0c ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r15, r0"
+
+  -
+    input:
+      bytes: [ 0x0f, 0x0f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r16, r31"
+
+  -
+    input:
+      bytes: [ 0xf0, 0x0f ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr" ]
+    expected:
+      insns:
+        -
+          asm_text: "add r31, r16"

--- a/tests/MC/AVR/syntax_reg_pair_avr_addsubiw.txt.yaml
+++ b/tests/MC/AVR/syntax_reg_pair_avr_addsubiw.txt.yaml
@@ -1,0 +1,30 @@
+test_cases:
+  -
+    input:
+      bytes: [ 0x01, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r24, 1"
+
+  -
+    input:
+      bytes: [ 0x02, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r24, 2"
+
+  -
+    input:
+      bytes: [ 0x13, 0x97 ]
+      arch: "CS_ARCH_AVR"
+      options: [ "avr", "addsubiw" ]
+    expected:
+      insns:
+        -
+          asm_text: "sbiw r26, 3"


### PR DESCRIPTION
I generated the MC tests for you, so you can test your module properly.
Those should be most (or all) instructions LLVM supports.
If you don't want to support all of them you can delete the test files for the ones you don't implement.